### PR TITLE
Automatically create directory(-ies) in the path

### DIFF
--- a/DigiMovie/Helpers/FileManager.cs
+++ b/DigiMovie/Helpers/FileManager.cs
@@ -26,6 +26,7 @@ namespace DigiMovie.Helpers
         public void SaveFile(IFormFile file, string path)
         {
             var absolutePath = Path.Combine(_env.WebRootPath, path);
+            Directory.CreateDirectory(Path.GetDirectoryName(absolutePath));
 
             using (var fileStream = new FileStream(absolutePath, FileMode.Create))
             {


### PR DESCRIPTION
Creates all directories and subdirectory in the specified path unless they already exist.
https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.createdirectory?view=netcore-2.1

Path.GetDirectoryName(absolutePath) Returns the directory information for the specified path string.
https://docs.microsoft.com/en-us/dotnet/api/system.io.path.getdirectoryname?view=netcore-2.1